### PR TITLE
Add support for pointers to structs and values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+.idea/

--- a/configs/correct.yaml
+++ b/configs/correct.yaml
@@ -15,3 +15,10 @@ builtin:
     blah: blah
 
 number: 42
+
+ptrstruct:
+  ptrblah: blah
+  ptroptional: optional
+
+ptroptional:
+  ptrblah: blah

--- a/configs/missing4.yaml
+++ b/configs/missing4.yaml
@@ -2,7 +2,10 @@ key: val
 
 env: {{.Env.SOME_ENV_KEY}}
 
+bool: true
+
 builtin:
+  anotherkey: anothervalue
   mandatory: onemorevalue
   onemorebuiltin:
     blah: blah
@@ -11,3 +14,8 @@ number: 42
 
 ptrstruct:
   ptrblah: blah
+  ptroptional: optional
+
+ptroptional:
+  ptrfoo: blah
+

--- a/configs/missing5.yaml
+++ b/configs/missing5.yaml
@@ -1,0 +1,1 @@
+optional: false


### PR DESCRIPTION
## Purpose
Currently when calling `cfg.LoadConfig()` on a struct with pointers to structs that are **not optional** `cfg.LoadConfig()` panics with `panic: reflect: call of reflect.Value.Len on ptr Value`. This PR adds full support for pointers to values and sub structs. As a side benefit, integers and booleans can now differentiate between not provided and zero value by defining the value as a pointer
```go
type Config struct {
	Optional  *bool
	Mandatory *bool
}
// Given configs/missing.yaml contains
// optional: false

config := Config{}
err := LoadConfig("configs/missing.yaml", &config)
// err == "Missing required config field: Mandatory of type *bool")
```

## Implementation
* Refactored `validate()` to support de-referencing pointers
* `validate()` violations now include the full struct name and type of the offending field
```go
// Given
type Config struct {
	Builtin struct {
		Mandatory      string
	}
}
config := Config{}
err := LoadConfig("configs/missing2.yaml", &config)
// err.Error() == "Missing required config field: Builtin.Mandatory of type string"
// Instead of
// err.Error() == "Missing required config field: Mandatory"
```